### PR TITLE
Support various bundling systems

### DIFF
--- a/webpack.config.npm.js
+++ b/webpack.config.npm.js
@@ -12,8 +12,18 @@ module.exports = {
 		libraryTarget: 'umd',
 		globalObject: 'this',
 	},
-	externals: {
-		'react': 'React',
-		'react-dom': 'ReactDOM',
-	},
+	externals: {         
+		react: {          
+		    commonjs: "react",          
+		    commonjs2: "react",          
+		    amd: "React",          
+		    root: "React"      
+		},      
+		"react-dom": {          
+		    commonjs: "react-dom",          
+		    commonjs2: "react-dom",          
+		    amd: "ReactDOM",          
+		    root: "ReactDOM"      
+		}  
+    	} 
 }


### PR DESCRIPTION
I keep seeing an error which says "ReactDOM" not found when using this module. Changing the module to "react-dom" seemed to fix it. So I think this change will overall make this module work irrespective of the bundling mechanism used. This will allow this component to be used by systems like nextjs.

Ive published [@roopakv/sarif-web-component](https://www.npmjs.com/package/@roopakv/sarif-web-component) with this change, systems built on nextjs, etc work\

cc @jeffersonking