### PR TITLE
Update hljs to use highlightElement

### DIFF
--- a/components/Snippet.tsx
+++ b/components/Snippet.tsx
@@ -87,7 +87,7 @@ import { ContentSize } from 'azure-devops-ui/Callout'
 				ref={code => {
 					if (!code) return
 					try {
-						hljs.highlightBlock(code)
+						hljs.highlightElement(code)
 					} catch(e) {
 						// Commonly throws if the language is not loaded. Will add telemetry here to track.
 						console.log(code, e)


### PR DESCRIPTION
Hi there, highlightBlock is deprecated since version 10.7. This PR addresses the console log message below.
```
Deprecated as of 10.7.0. highlightBlock will be removed entirely in v12.0
Deprecated as of 10.7.0. Please use highlightElement now.
```
