### PR TITLE
Update Extension URI to Bootstrapper URL

### DIFF
--- a/components/RunStore.ts
+++ b/components/RunStore.ts
@@ -82,7 +82,7 @@ export class RunStore {
 				if (isRepositoryDetailsComplete(repoDetails) && buildId && artifactName && filePath) {
 					const fixInVsCodeAction = {
 						text: 'Fix in VS Code',
-						linkUrl: `vscode://devprod.vulnerability-extension/import?buildId=${buildId}&artifactName=${artifactName}&filePath=${filePath}&organization=${repoDetails.organizationName}&project=${repoDetails.projectName}&repoName=${repoDetails.repositoryName}&runIndex=${run._index}&resultIndex=${resultIndex++}&source=1esscans`,
+						linkUrl: `https://waveanalysis.microsoft.com/import?buildId=${buildId}&artifactName=${artifactName}&filePath=${filePath}&organization=${repoDetails.organizationName}&project=${repoDetails.projectName}&repoName=${repoDetails.repositoryName}&runIndex=${run._index}&resultIndex=${resultIndex++}&source=1esscans`,
 						imageName: 'vscode',
 						className: 'vscode-action'
 					}


### PR DESCRIPTION
Switched "Fix in VS Code" link from `vscode://devprod.vulnerability-extension/import?${params}` to `https://waveanalysis.microsoft.com/import?${params}`.

The WAVE Analysis team has switched from leveraging our direct extension URI to the URL for a landing webpage to improve context for users and our telemetry on user behavior. We have been introducing this change in our other entry points (S360, AzDO OneClick, etc.) - this PR introduces that change into the Scans Tab extension.