### PR TITLE
Fix Publish Workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: '14.17.0'
+        node-version: '14'
+        check-latest: true
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
     - run: npx webpack --config ./webpack.config.npm.js

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,10 +10,15 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
-        check-latest: true
         registry-url: 'https://registry.npmjs.org'
+    # Dependency node-sass will not install without Python 2; need to install.
+    - name: Install Python 2
+      run: |
+        brew install python@2
+        echo 'export PATH="/usr/local/opt/python@2/bin:$PATH"' >> ~/.bash_profile
+        source ~/.bash_profile
     - run: npm install
     - run: npx webpack --config ./webpack.config.npm.js
-    - run: npm publish
+    #- run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,8 +16,11 @@ jobs:
       run: |
         curl -O https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg
         sudo installer -pkg python-2.7.18-macosx10.9.pkg -target /
+        echo 'export PATH="/Library/Frameworks/Python.framework/Versions/2.7/bin:$PATH"' >> $GITHUB_ENV
         echo 'export PYTHON="/Library/Frameworks/Python.framework/Versions/2.7/bin/python2"' >> $GITHUB_ENV
     - run: npm install
+      env:
+        PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python2"
     - run: npx webpack --config ./webpack.config.npm.js
     #- run: npm publish
       env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,9 +14,9 @@ jobs:
     # Dependency node-sass will not install without Python 2; need to install.
     - name: Install Python 2
       run: |
-        brew install python@2
-        echo 'export PATH="/usr/local/opt/python@2/bin:$PATH"' >> ~/.bash_profile
-        source ~/.bash_profile
+        curl -O https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg
+        sudo installer -pkg python-2.7.18-macosx10.9.pkg -target /
+        echo 'export PATH="/Library/Frameworks/Python.framework/Versions/2.7/bin:$PATH"' >> $GITHUB_ENV
     - run: npm install
     - run: npx webpack --config ./webpack.config.npm.js
     #- run: npm publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,6 +22,6 @@ jobs:
       env:
         PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python2"
     - run: npx webpack --config ./webpack.config.npm.js
-    #- run: npm publish
+    - run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '16'
         check-latest: true
         registry-url: 'https://registry.npmjs.org'
     - run: npm install

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,16 +11,7 @@ jobs:
       with:
         node-version: '16'
         registry-url: 'https://registry.npmjs.org'
-    # Dependency node-sass will not install without Python 2; need to install.
-    - name: Install Python 2
-      run: |
-        curl -O https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg
-        sudo installer -pkg python-2.7.18-macosx10.9.pkg -target /
-        echo 'export PATH="/Library/Frameworks/Python.framework/Versions/2.7/bin:$PATH"' >> $GITHUB_ENV
-        echo 'export PYTHON="/Library/Frameworks/Python.framework/Versions/2.7/bin/python2"' >> $GITHUB_ENV
     - run: npm install
-      env:
-        PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python2"
     - run: npx webpack --config ./webpack.config.npm.js
     - run: npm publish
       env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,11 +16,7 @@ jobs:
       run: |
         curl -O https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg
         sudo installer -pkg python-2.7.18-macosx10.9.pkg -target /
-        echo 'export PATH="/Library/Frameworks/Python.framework/Versions/2.7/bin:$PATH"' >> $GITHUB_ENV
-    - name: Install distutils
-      run: |
-        sudo /Library/Frameworks/Python.framework/Versions/2.7/bin/python2 -m ensurepip
-        sudo /Library/Frameworks/Python.framework/Versions/2.7/bin/python2 -m pip install --upgrade pip setuptools
+        echo 'export PYTHON="/Library/Frameworks/Python.framework/Versions/2.7/bin/python2"' >> $GITHUB_ENV
     - run: npm install
     - run: npx webpack --config ./webpack.config.npm.js
     #- run: npm publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '14.17.0'
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
     - run: npx webpack --config ./webpack.config.npm.js

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,6 +17,10 @@ jobs:
         curl -O https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg
         sudo installer -pkg python-2.7.18-macosx10.9.pkg -target /
         echo 'export PATH="/Library/Frameworks/Python.framework/Versions/2.7/bin:$PATH"' >> $GITHUB_ENV
+    - name: Install distutils
+      run: |
+        sudo /Library/Frameworks/Python.framework/Versions/2.7/bin/python2 -m ensurepip
+        sudo /Library/Frameworks/Python.framework/Versions/2.7/bin/python2 -m pip install --upgrade pip setuptools
     - run: npm install
     - run: npx webpack --config ./webpack.config.npm.js
     #- run: npm publish

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"react-markdown": "^4.0.8",
 		"sass": "^1.80.6",
 		"uri-join": "^1.0.1",
-        "vss-web-extension-sdk": "^5.141.0"
+		"vss-web-extension-sdk": "^5.141.0"
 	},
 	"peerDependencies": {
 		"react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
 		"test": "jest",
 		"test:watch": "jest --watchAll",
 		"npm": "webpack --config ./webpack.config.npm.js",
-		"docs": "webpack --config ./webpack.config.docs.js",
-		"build-css": "node-sass src/styles -o dist/styles"
+		"docs": "webpack --config ./webpack.config.docs.js"
 	},
 	"devDependencies": {
 		"@babel/preset-env": "^7.4.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"enzyme-adapter-react-16": "^1.15.6",
 		"identity-obj-proxy": "^3.0.0",
 		"jest": "^27.0.4",
-		"node-sass": "^6.0.0",
 		"react": "^16.8.6",
 		"react-dom": "^16.8.6",
 		"sass-loader": "^10.1.1",
@@ -52,7 +51,9 @@
 		"mobx-utils": "^5.5.5",
 		"react-linkify": "^1.0.0-alpha",
 		"react-markdown": "^4.0.8",
-		"uri-join": "^1.0.1"
+		"sass": "^1.80.6",
+		"uri-join": "^1.0.1",
+        "vss-web-extension-sdk": "^5.141.0"
 	},
 	"peerDependencies": {
 		"react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"test": "jest",
 		"test:watch": "jest --watchAll",
 		"npm": "webpack --config ./webpack.config.npm.js",
-		"docs": "webpack --config ./webpack.config.docs.js"
+		"docs": "webpack --config ./webpack.config.docs.js",
+		"build-css": "node-sass src/styles -o dist/styles"
 	},
 	"devDependencies": {
 		"@babel/preset-env": "^7.4.5",
@@ -29,10 +30,10 @@
 		"enzyme-adapter-react-16": "^1.15.6",
 		"identity-obj-proxy": "^3.0.0",
 		"jest": "^27.0.4",
-		"node-sass": "^4.14.1",
+		"node-sass": "^6.0.0",
 		"react": "^16.8.6",
 		"react-dom": "^16.8.6",
-		"sass-loader": "^7.1.0",
+		"sass-loader": "^10.1.1",
 		"style-loader": "^0.23.1",
 		"ts-jest": "^27.0.4",
 		"ts-loader": "^8.1.0",
@@ -51,8 +52,7 @@
 		"mobx-utils": "^5.5.5",
 		"react-linkify": "^1.0.0-alpha",
 		"react-markdown": "^4.0.8",
-		"uri-join": "^1.0.1",
-		"vss-web-extension-sdk": "^5.141.0"
+		"uri-join": "^1.0.1"
 	},
 	"peerDependencies": {
 		"react": "^16.8.6",


### PR DESCRIPTION
Node 14 does not have a binary for darwin arm64 per [this GitHub issue](https://github.com/nvm-sh/nvm/issues/3148):
![image](https://github.com/user-attachments/assets/931174f5-fa91-4833-960c-9af310d6ec7f)

- Updated to Node 16.
- Updated `node-sass` for compatibility.
- Added Python2 for `node-sass` installation.
- Validated with [this build](https://github.com/microsoft/sarif-web-component/actions/runs/11788040080), which runs everything successfully save the actual publish.
